### PR TITLE
Fix API deploy Node version

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -24,6 +24,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: backend-ts/package-lock.json
+
       - name: Check if API image is up to date
         id: image-check
         run: make api-image-check


### PR DESCRIPTION
## Summary
- Install Node 22 in the API deploy workflow before running Make targets
- Keeps PR CI and CD runtime aligned with backend-ts engine requirements

## Validation
- git diff --check