### PR TITLE
Fix API deploy image tag propagation

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -19,6 +19,8 @@ jobs:
   build:
     name: Build and Deploy API
     runs-on: ubuntu-latest
+    outputs:
+      api_version: ${{ steps.api_version.outputs.api_version }}
     
     steps:
       - name: Checkout code
@@ -41,11 +43,16 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         continue-on-error: true
 
+      - name: Capture API version
+        id: api_version
+        run: echo "api_version=$(make api-version)" >> "$GITHUB_OUTPUT"
+
       - name: Download data and Build API
         run: make api-build
         env:
           REGISTRY: ${{ secrets.REGISTRY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          API_VERSION: ${{ steps.api_version.outputs.api_version }}
         if: steps.image-check.outcome == 'failure'
 
       - name: Publish API docker image
@@ -54,6 +61,7 @@ jobs:
           REGISTRY: ${{ secrets.REGISTRY }}
           DOCKER_USERNAME: nologin
           DOCKER_PASSWORD: ${{ secrets.SCW_SECRET_KEY }}
+          API_VERSION: ${{ steps.api_version.outputs.api_version }}
         if: steps.image-check.outcome == 'failure'
 
   deploy:
@@ -80,3 +88,4 @@ jobs:
         run: make deploy-api
         env:
           REGISTRY: ${{ secrets.REGISTRY }}
+          API_VERSION: ${{ needs.build.outputs.api_version }}

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .SILENT:
-.PHONY: dev dev-stop up down ui-install ui-build ui-check docker-build docker-push build deploy deps env config clean help api-prepare-data-ci api-build api-install api-image-publish api-test api-smoke api-contracts api-review-routing check deploy-api dataprep dataprep-prepare-tech-docs dataprep-tech-docs dataprep-nc dataprep-knowledge dataprep-knowledge-tech-docs dataprep-knowledge-ci
+.PHONY: dev dev-stop up down ui-install ui-build ui-check docker-build docker-push build deploy deps env config clean help api-version api-prepare-data-ci api-build api-install api-image-publish api-test api-smoke api-contracts api-review-routing check deploy-api dataprep dataprep-prepare-tech-docs dataprep-tech-docs dataprep-nc dataprep-knowledge dataprep-knowledge-tech-docs dataprep-knowledge-ci
 
 # ----------------------------
 # Helpers
@@ -34,6 +34,9 @@ export DC_OPTS         ?= --build --force-recreate
 
 version:
 	@echo ui:$(UI_VERSION)-api:$(API_VERSION)
+
+api-version:
+	@echo $(API_VERSION)
 
 dev:
 	@echo "▶ Starting API and UI in dev mode with Docker..."


### PR DESCRIPTION
## Summary
- Capture the API image version computed after CI dataprep in the build job
- Reuse that exact tag for build, publish, and Scaleway deploy
- Add a small Make target to print only the API version

## Validation
- git diff --check
- make api-version