### PR TITLE
Fix API build retrieval artifacts

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -41,6 +41,8 @@ jobs:
           DOCKER_USERNAME: nologin
           DOCKER_PASSWORD: ${{ secrets.SCW_SECRET_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          S3_DATAPREP_ACCESS_KEY: ${{ secrets.SCW_ACCESS_KEY }}
+          S3_DATAPREP_SECRET_KEY: ${{ secrets.SCW_SECRET_KEY }}
         continue-on-error: true
 
       - name: Capture API version
@@ -52,6 +54,8 @@ jobs:
         env:
           REGISTRY: ${{ secrets.REGISTRY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          S3_DATAPREP_ACCESS_KEY: ${{ secrets.SCW_ACCESS_KEY }}
+          S3_DATAPREP_SECRET_KEY: ${{ secrets.SCW_SECRET_KEY }}
           API_VERSION: ${{ steps.api_version.outputs.api_version }}
         if: steps.image-check.outcome == 'failure'
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .SILENT:
-.PHONY: dev dev-stop up down ui-install ui-build ui-check docker-build docker-push build deploy deps env config clean help api-version api-prepare-data-ci api-build api-install api-image-publish api-test api-smoke api-contracts api-review-routing check deploy-api dataprep dataprep-prepare-tech-docs dataprep-tech-docs dataprep-nc dataprep-knowledge dataprep-knowledge-tech-docs dataprep-knowledge-ci
+.PHONY: dev dev-stop up down ui-install ui-build ui-check docker-build docker-push build deploy deps env config clean help api-version api-prepare-data-ci api-build api-install api-image-publish api-test api-smoke api-contracts api-review-routing check deploy-api dataprep dataprep-prepare-tech-docs dataprep-tech-docs dataprep-nc dataprep-knowledge dataprep-knowledge-tech-docs dataprep-knowledge-ci dataprep-retrieval-ci dataprep-upload-retrieval-cache
 
 # ----------------------------
 # Helpers
@@ -11,7 +11,7 @@
 # ----------------------------
 export UI_DIR          ?= ui
 export API_IMAGE_NAME  ?= nc-chatbot-api
-export API_VERSION     ?= $(shell echo "backend-ts/src backend-ts/scripts backend-ts/package.json backend-ts/package-lock.json backend-ts/Dockerfile shared api/src api/requirements.txt api/data/${TECH_DOCS_DIR}/ontology api/data/${TECH_DOCS_DIR}/wiki api/data/${NC_DIR}/ontology api/data/${NC_DIR}/wiki" | tr ' ' '\n' | xargs -I '{}' sh -c 'test -e "$$1" && find "$$1" -type f || true' sh '{}' | egrep -v '(__pycache__|/ontology/index\.json)' | sort | xargs cat | sha1sum - | sed 's/\(......\).*/\1/')
+export API_VERSION     ?= $(shell echo "backend-ts/src backend-ts/scripts backend-ts/package.json backend-ts/package-lock.json backend-ts/Dockerfile shared api/src api/requirements.txt api/data/${TECH_DOCS_DIR}/lexical api/data/${TECH_DOCS_DIR}/ontology api/data/${TECH_DOCS_DIR}/vector-export api/data/${TECH_DOCS_DIR}/wiki api/data/${TECH_DOCS_DIR}/knowledge-manifest.json api/data/${NC_DIR}/lexical api/data/${NC_DIR}/ontology api/data/${NC_DIR}/vector-export api/data/${NC_DIR}/wiki api/data/${NC_DIR}/knowledge-manifest.json" | tr ' ' '\n' | xargs -I '{}' sh -c 'test -e "$$1" && find "$$1" -type f || true' sh '{}' | egrep -v '(__pycache__|/ontology/index\.json)' | sort | xargs cat | sha1sum - | sed 's/\(......\).*/\1/')
 export API_CPU_LIMIT   ?= 250
 export API_MEM_LIMIT   ?= 512
 export UI_VERSION      ?= $(shell echo "ui/src ui/static ui/package.json ui/Dockerfile ui/vite.config.ts ui/svelte.config.js ui/tsconfig.json" | tr ' ' '\n' | xargs -I '{}' find {} -type f | egrep -v '__pycache__'  | sort | xargs cat | sha1sum - | sed 's/\(......\).*/\1/')
@@ -81,7 +81,7 @@ ui-check: ui-install
 # Containerisation
 # ----------------------------
 
-api-prepare-data-ci: dataprep-knowledge-ci
+api-prepare-data-ci: dataprep-retrieval-ci
 	@echo "✔️ API data artifacts ready for CI image build."
 
 api-build: api-prepare-data-ci
@@ -135,6 +135,11 @@ dataprep-knowledge-tech-docs: api-install
 dataprep-knowledge-ci: dataprep-download-minimal api-install
 	@echo "▶ Preparing knowledge artifacts for API image..."
 	cd backend-ts && npm run dataprep:knowledge
+
+dataprep-retrieval-ci: dataprep-download-minimal api-install
+	@echo "▶ Ensuring retrieval artifacts for API image..."
+	cd backend-ts && npm run dataprep:ensure-retrieval
+	$(MAKE) dataprep-upload-retrieval-cache
 
 check: ui-build api-test api-contracts
 	@echo "✔️ UI build and backend checks completed."
@@ -233,6 +238,29 @@ dataprep-upload-tech-docs: check-s5cmd
 	export AWS_SECRET_ACCESS_KEY=${S3_DATAPREP_SECRET_KEY} &&\
 	s5cmd --endpoint-url ${S3_ENDPOINT_URL} \
 		cp --acl "public-read" 'api/data/${S3_BUCKET_DOCS}/*' s3://${S3_BUCKET_DOCS}/
+
+dataprep-upload-retrieval-cache: check-s5cmd
+	@if [ "${DATAPREP_UPLOAD_RETRIEVAL_CACHE}" = "0" ]; then \
+		echo "↷ Retrieval cache upload disabled."; \
+	elif [ -z "${S3_DATAPREP_ACCESS_KEY}" ] || [ -z "${S3_DATAPREP_SECRET_KEY}" ]; then \
+		echo "↷ S3_DATAPREP_ACCESS_KEY/S3_DATAPREP_SECRET_KEY missing; retrieval cache upload skipped."; \
+	else \
+		echo "▶ Uploading retrieval cache artifacts to Scaleway..."; \
+		export AWS_ACCESS_KEY_ID=${S3_DATAPREP_ACCESS_KEY}; \
+		export AWS_SECRET_ACCESS_KEY=${S3_DATAPREP_SECRET_KEY}; \
+		s5cmd --endpoint-url ${S3_ENDPOINT_URL} cp --acl "public-read" 'api/data/${TECH_DOCS_DIR}/lexical/*' s3://${S3_BUCKET_DOCS}/lexical/ && \
+		s5cmd --endpoint-url ${S3_ENDPOINT_URL} cp --acl "public-read" 'api/data/${TECH_DOCS_DIR}/vector-export/*' s3://${S3_BUCKET_DOCS}/vector-export/ && \
+		s5cmd --endpoint-url ${S3_ENDPOINT_URL} cp --acl "public-read" 'api/data/${TECH_DOCS_DIR}/ontology/*' s3://${S3_BUCKET_DOCS}/ontology/ && \
+		s5cmd --endpoint-url ${S3_ENDPOINT_URL} cp --acl "public-read" 'api/data/${TECH_DOCS_DIR}/wiki/index.json' s3://${S3_BUCKET_DOCS}/wiki/index.json && \
+		if [ -d 'api/data/${TECH_DOCS_DIR}/wiki/parts' ]; then s5cmd --endpoint-url ${S3_ENDPOINT_URL} cp --acl "public-read" 'api/data/${TECH_DOCS_DIR}/wiki/parts/*' s3://${S3_BUCKET_DOCS}/wiki/parts/; fi && \
+		s5cmd --endpoint-url ${S3_ENDPOINT_URL} cp --acl "public-read" 'api/data/${TECH_DOCS_DIR}/knowledge-manifest.json' s3://${S3_BUCKET_DOCS}/knowledge-manifest.json && \
+		s5cmd --endpoint-url ${S3_ENDPOINT_URL} cp --acl "public-read" 'api/data/${NC_DIR}/lexical/*' s3://${S3_BUCKET_NC}/lexical/ && \
+		s5cmd --endpoint-url ${S3_ENDPOINT_URL} cp --acl "public-read" 'api/data/${NC_DIR}/vector-export/*' s3://${S3_BUCKET_NC}/vector-export/ && \
+		s5cmd --endpoint-url ${S3_ENDPOINT_URL} cp --acl "public-read" 'api/data/${NC_DIR}/ontology/*' s3://${S3_BUCKET_NC}/ontology/ && \
+		s5cmd --endpoint-url ${S3_ENDPOINT_URL} cp --acl "public-read" 'api/data/${NC_DIR}/wiki/index.json' s3://${S3_BUCKET_NC}/wiki/index.json && \
+		if [ -d 'api/data/${NC_DIR}/wiki/parts' ]; then s5cmd --endpoint-url ${S3_ENDPOINT_URL} cp --acl "public-read" 'api/data/${NC_DIR}/wiki/parts/*' s3://${S3_BUCKET_NC}/wiki/parts/; fi && \
+		s5cmd --endpoint-url ${S3_ENDPOINT_URL} cp --acl "public-read" 'api/data/${NC_DIR}/knowledge-manifest.json' s3://${S3_BUCKET_NC}/knowledge-manifest.json; \
+	fi
 
 dataprep-upload-all: dataprep-upload-nc-data dataprep-upload-tech-docs
 	@echo "✔️  All data upload completed."

--- a/backend-ts/package.json
+++ b/backend-ts/package.json
@@ -17,6 +17,7 @@
     "dataprep": "npm run dataprep:prepare-tech-docs && node --experimental-strip-types scripts/run_dataprep.ts all",
     "dataprep:tech-docs": "npm run dataprep:prepare-tech-docs && node --experimental-strip-types scripts/run_dataprep.ts tech_docs",
     "dataprep:nc": "node --experimental-strip-types scripts/run_dataprep.ts non_conformities",
+    "dataprep:ensure-retrieval": "npm run dataprep:prepare-tech-docs && node --experimental-strip-types scripts/ensure_retrieval_artifacts.ts all",
     "dataprep:knowledge": "npm run dataprep:prepare-tech-docs && node --experimental-strip-types scripts/run_knowledge_dataprep.ts all",
     "dataprep:knowledge:tech-docs": "npm run dataprep:prepare-tech-docs && node --experimental-strip-types scripts/run_knowledge_dataprep.ts tech_docs"
   }

--- a/backend-ts/scripts/ensure_retrieval_artifacts.ts
+++ b/backend-ts/scripts/ensure_retrieval_artifacts.ts
@@ -1,0 +1,49 @@
+import {
+  DEFAULT_EMBEDDING_MODEL,
+  buildDataprepCodeFingerprint,
+  buildDataprepCliOptions,
+  buildDefaultCorpusConfigs,
+  buildSourceFingerprint,
+  inspectRetrievalArtifacts,
+  readPreparedRecords,
+  runDataprepForCorpus,
+  type DataprepCorpusName,
+  type RunDataprepOptions,
+} from "../src/dataprep/pipeline.ts";
+
+const requested = process.argv[2] ?? "all";
+const corpusNames: readonly DataprepCorpusName[] =
+  requested === "all" ? ["tech_docs", "non_conformities"] : [requested as DataprepCorpusName];
+const configs = buildDefaultCorpusConfigs();
+const codeFingerprint = buildDataprepCodeFingerprint();
+let options: RunDataprepOptions | null = null;
+
+for (const corpus of corpusNames) {
+  const config = configs[corpus];
+  if (!config) {
+    throw new Error(`Unknown dataprep corpus '${corpus}'`);
+  }
+
+  const records = readPreparedRecords(config);
+  const fingerprint = buildSourceFingerprint(config, records);
+  const status = inspectRetrievalArtifacts(config, {
+    fingerprint,
+    codeFingerprint,
+    recordCount: records.length,
+    embeddingModel: DEFAULT_EMBEDDING_MODEL,
+  });
+
+  if (status.fresh) {
+    console.log(`retrieval artifacts fresh: ${corpus} (${records.length} records)`);
+    continue;
+  }
+
+  console.log(`retrieval artifacts stale: ${corpus}`);
+  for (const reason of status.reasons) {
+    console.log(`- ${reason}`);
+  }
+
+  options ??= buildDataprepCliOptions();
+  await runDataprepForCorpus(config, options);
+  console.log(`retrieval artifacts rebuilt: ${corpus} (${records.length} records)`);
+}

--- a/backend-ts/src/dataprep/pipeline.ts
+++ b/backend-ts/src/dataprep/pipeline.ts
@@ -110,12 +110,17 @@ type MutablePartCanonicalizerInput = {
 };
 
 const API_ROOT = fileURLToPath(new URL("../../../api/", import.meta.url));
-const DEFAULT_EMBEDDING_MODEL = process.env.DATAPREP_EMBEDDING_MODEL?.trim() || "text-embedding-3-large";
+export const DEFAULT_EMBEDDING_MODEL = process.env.DATAPREP_EMBEDDING_MODEL?.trim() || "text-embedding-3-large";
+export const RETRIEVAL_ARTIFACT_CACHE_VERSION = "retrieval-artifacts-v1";
 const DEFAULT_PART_CANONICALIZATION_MODEL =
   process.env.DATAPREP_LLM_MODEL?.trim() || "gpt-5.4-nano";
 
 const TECH_DOCS_DIR = process.env.TECH_DOCS_DIR?.trim() || "a220-tech-docs";
 const NC_DIR = process.env.NC_DIR?.trim() || "a220-non-conformities";
+const DATAPREP_CODE_FINGERPRINT_FILES = [
+  fileURLToPath(import.meta.url),
+  fileURLToPath(new URL("./tech-docs-canonical.ts", import.meta.url)),
+];
 
 const ZONE_PATTERNS: readonly [RegExp, string][] = [
   [/\bRH\b/giu, "RH"],
@@ -431,14 +436,37 @@ export function readPreparedRecords(config: DataprepCorpusConfig): PreparedRecor
   return normalized;
 }
 
+export function buildDataprepCodeFingerprint(): string {
+  const hash = createHash("sha256");
+  for (const filePath of DATAPREP_CODE_FINGERPRINT_FILES) {
+    hash.update(path.basename(filePath));
+    hash.update("\n");
+    hash.update(readFileSync(filePath));
+    hash.update("\n");
+  }
+  return hash.digest("hex");
+}
+
+function stableMetadataString(metadata: Readonly<Record<string, unknown>>): string {
+  return JSON.stringify(
+    Object.fromEntries(Object.keys(metadata).sort().map((key) => [key, metadata[key]])),
+  );
+}
+
 export function buildSourceFingerprint(config: DataprepCorpusConfig, records: readonly PreparedRecord[]): string {
   const hash = createHash("sha256");
-  hash.update(config.sourceFile);
+  hash.update(config.corpus);
   hash.update("\n");
   for (const record of records) {
     hash.update(record.doc);
     hash.update("\n");
     hash.update(record.chunk_id);
+    hash.update("\n");
+    hash.update(record.source_path);
+    hash.update("\n");
+    hash.update(record.content);
+    hash.update("\n");
+    hash.update(stableMetadataString(record.metadata));
     hash.update("\n");
   }
   return hash.digest("hex");
@@ -602,6 +630,135 @@ function buildLexicalIndex(
   return {
     dbPath: path.join(targetRoot, "fts.sqlite3"),
     documentCount: records.length,
+  };
+}
+
+export interface RetrievalArtifactStatus {
+  readonly corpus: DataprepCorpusName;
+  readonly fresh: boolean;
+  readonly reasons: readonly string[];
+}
+
+function fileExists(filePath: string): boolean {
+  return existsSync(filePath);
+}
+
+function readJsonFile(filePath: string): Record<string, unknown> | null {
+  if (!fileExists(filePath)) {
+    return null;
+  }
+  try {
+    return JSON.parse(readFileSync(filePath, "utf8")) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+function readLexicalDocumentCount(dbPath: string): number | null {
+  if (!fileExists(dbPath)) {
+    return null;
+  }
+  try {
+    const db = new DatabaseSync(dbPath);
+    const row = db.prepare("SELECT COUNT(*) AS count FROM lexical_documents").get() as
+      | { count: number }
+      | undefined;
+    db.close();
+    return typeof row?.count === "number" ? row.count : null;
+  } catch {
+    return null;
+  }
+}
+
+export function inspectRetrievalArtifacts(
+  config: DataprepCorpusConfig,
+  expected: {
+    readonly fingerprint: string;
+    readonly codeFingerprint: string;
+    readonly recordCount: number;
+    readonly embeddingModel: string;
+  },
+): RetrievalArtifactStatus {
+  const reasons: string[] = [];
+  const manifestPath = path.join(config.outputRoot, "knowledge-manifest.json");
+  const manifest = readJsonFile(manifestPath);
+  if (!manifest) {
+    reasons.push("knowledge-manifest.json missing or invalid");
+  } else {
+    if (manifest.corpus !== config.corpus) {
+      reasons.push("knowledge manifest corpus mismatch");
+    }
+    if (manifest.mode === "knowledge-only") {
+      reasons.push("knowledge manifest is knowledge-only");
+    }
+    if (manifest.retrievalArtifactCacheVersion !== RETRIEVAL_ARTIFACT_CACHE_VERSION) {
+      reasons.push("retrieval artifact cache version mismatch");
+    }
+    if (manifest.fingerprint !== expected.fingerprint) {
+      reasons.push("knowledge manifest fingerprint mismatch");
+    }
+    if (manifest.retrievalArtifactCodeFingerprint !== expected.codeFingerprint) {
+      reasons.push("retrieval artifact code fingerprint mismatch");
+    }
+    if (manifest.embeddingModel !== expected.embeddingModel) {
+      reasons.push("embedding model mismatch");
+    }
+    if (manifest.recordCount !== expected.recordCount) {
+      reasons.push("knowledge manifest record count mismatch");
+    }
+    if (!manifest.vectorExport) {
+      reasons.push("knowledge manifest missing vectorExport section");
+    }
+    if (!manifest.lexical) {
+      reasons.push("knowledge manifest missing lexical section");
+    }
+  }
+
+  const vectorRoot = path.join(config.outputRoot, "vector-export");
+  const vectorManifest = readJsonFile(path.join(vectorRoot, "manifest.json"));
+  for (const filename of ["items.jsonl", "vectors.f32", "squared_norms.f32"]) {
+    if (!fileExists(path.join(vectorRoot, filename))) {
+      reasons.push(`vector-export/${filename} missing`);
+    }
+  }
+  if (!vectorManifest) {
+    reasons.push("vector-export/manifest.json missing or invalid");
+  } else {
+    if (vectorManifest.corpus !== config.corpus) {
+      reasons.push("vector manifest corpus mismatch");
+    }
+    if (vectorManifest.embeddingModel !== expected.embeddingModel) {
+      reasons.push("vector manifest embedding model mismatch");
+    }
+    if (vectorManifest.count !== expected.recordCount) {
+      reasons.push("vector manifest count mismatch");
+    }
+  }
+
+  const lexicalDbPath = path.join(config.outputRoot, "lexical", "fts.sqlite3");
+  const lexicalCount = readLexicalDocumentCount(lexicalDbPath);
+  if (lexicalCount === null) {
+    reasons.push("lexical/fts.sqlite3 missing or invalid");
+  } else if (lexicalCount !== expected.recordCount) {
+    reasons.push("lexical document count mismatch");
+  }
+
+  const ontologyRoot = path.join(config.outputRoot, "ontology");
+  for (const filename of ["atas.json", "parts.json", "zones.json", "relations.json", "occurrences.json", "index.json"]) {
+    if (!fileExists(path.join(ontologyRoot, filename))) {
+      reasons.push(`ontology/${filename} missing`);
+    }
+  }
+
+  const wikiRoot = path.join(config.outputRoot, "wiki");
+  if (!fileExists(path.join(wikiRoot, "index.json"))) {
+    reasons.push("wiki/index.json missing");
+  }
+
+  return {
+    corpus: config.corpus,
+    fresh: reasons.length === 0,
+    reasons,
   };
 }
 
@@ -896,6 +1053,9 @@ function buildKnowledgeManifest(
         generatedAt: new Date().toISOString(),
         sourceFile: config.sourceFile,
         fingerprint,
+        mode: "full",
+        retrievalArtifactCacheVersion: RETRIEVAL_ARTIFACT_CACHE_VERSION,
+        retrievalArtifactCodeFingerprint: buildDataprepCodeFingerprint(),
         llmAssistMode: options.llmAssistMode ?? "off",
         embeddingModel: options.embeddingProvider.model,
         partCanonicalizerModel: options.partCanonicalizer?.model ?? null,

--- a/backend-ts/src/services/lexical-search.ts
+++ b/backend-ts/src/services/lexical-search.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, readFileSync, statSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { DatabaseSync } from "node:sqlite";
@@ -180,6 +180,17 @@ export function ensureLexicalIndexExists(config: LexicalCorpusConfig): {
   const row = db.prepare(`SELECT COUNT(*) AS count FROM lexical_documents`).get() as { count: number };
   const fingerprint = readMeta(db, "fingerprint");
   db.close();
+
+  if (row.count === 0 && !existsSync(config.sourceRoot)) {
+    return {
+      corpus: config.name,
+      dbPath: config.dbPath,
+      sourceRoot: config.sourceRoot,
+      documentCount: 0,
+      fingerprint,
+      rebuilt: false,
+    };
+  }
 
   if (row.count === 0) {
     return rebuildLexicalIndex(config);

--- a/backend-ts/test/dataprep-pipeline.test.ts
+++ b/backend-ts/test/dataprep-pipeline.test.ts
@@ -10,6 +10,10 @@ import {
   normalizeNcPreparedRow,
   normalizeTechDocsPreparedRow,
   parseDelimitedTable,
+  buildDataprepCodeFingerprint,
+  buildSourceFingerprint,
+  inspectRetrievalArtifacts,
+  readPreparedRecords,
   runDataprepForCorpus,
   runKnowledgeDataprepForCorpus,
   type DataprepCorpusConfig,
@@ -64,6 +68,57 @@ test("parseDelimitedTable preserves multiline quoted TSV fields", () => {
   const rows = parseDelimitedTable('a\t"line 1\nline 2"\tb\n');
   assert.equal(rows.length, 1);
   assert.deepEqual(rows[0], ["a", "line 1\nline 2", "b"]);
+});
+
+test("buildSourceFingerprint changes when prepared content changes", () => {
+  const root = buildTestRoot();
+  const sourceFile = path.join(root, "tech_docs.csv.gz");
+  const outputRoot = path.join(root, "tech");
+
+  const header = ["doc", "doc_root", "json_data", "chunk", "length", "chunk_id", "ata", "parts", "doc_type"];
+  writeGzipTsv(sourceFile, [
+    header,
+    [
+      "A220-ATA52-door-page_0001.pdf",
+      "A220-ATA52-door.pdf",
+      "A220-ATA52-door-page_0001.json",
+      "Original door inspection limits.",
+      "32",
+      "A220-ATA52-door-page_0001.pdf 0",
+      "ATA 52",
+      "Door Frame",
+      "procedure",
+    ],
+  ]);
+
+  const config: DataprepCorpusConfig = {
+    corpus: "tech_docs",
+    sourceFile,
+    outputRoot,
+    hasHeader: true,
+    normalizeRow: normalizeTechDocsPreparedRow,
+  };
+  const firstFingerprint = buildSourceFingerprint(config, readPreparedRecords(config));
+
+  writeGzipTsv(sourceFile, [
+    header,
+    [
+      "A220-ATA52-door-page_0001.pdf",
+      "A220-ATA52-door.pdf",
+      "A220-ATA52-door-page_0001.json",
+      "Updated door inspection limits.",
+      "31",
+      "A220-ATA52-door-page_0001.pdf 0",
+      "ATA 52",
+      "Door Frame",
+      "procedure",
+    ],
+  ]);
+
+  assert.notEqual(
+    firstFingerprint,
+    buildSourceFingerprint(config, readPreparedRecords(config)),
+  );
 });
 
 test("runDataprepForCorpus builds retrieval and knowledge artifacts from prepared corpora", async () => {
@@ -150,6 +205,17 @@ test("runDataprepForCorpus builds retrieval and knowledge artifacts from prepare
   const techManifest = JSON.parse(readFileSync(techResult.knowledgeManifestPath, "utf8")) as Record<string, unknown>;
   assert.equal(techManifest.corpus, "tech_docs");
   assert.equal(techManifest.embeddingModel, "fake-embedding-model");
+  assert.equal(techManifest.retrievalArtifactCacheVersion, "retrieval-artifacts-v1");
+  assert.equal(techManifest.retrievalArtifactCodeFingerprint, buildDataprepCodeFingerprint());
+  assert.deepEqual(
+    inspectRetrievalArtifacts(techConfig, {
+      fingerprint: String(techManifest.fingerprint),
+      codeFingerprint: buildDataprepCodeFingerprint(),
+      recordCount: techResult.recordCount,
+      embeddingModel: "fake-embedding-model",
+    }),
+    { corpus: "tech_docs", fresh: true, reasons: [] },
+  );
 
   const techParts = JSON.parse(
     readFileSync(path.join(techResult.ontology.root, "parts.json"), "utf8"),

--- a/backend-ts/test/lexical-search.test.ts
+++ b/backend-ts/test/lexical-search.test.ts
@@ -47,3 +47,17 @@ test("searchLexicalCorpus rebuilds and returns ranked matches", () => {
   assert.equal(results[0]?.doc, "ATA-56-demo.md");
   assert.equal(results[0]?.lexical_rank, 1);
 });
+
+test("searchLexicalCorpus returns empty results when source root is absent and index is empty", () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "nc-backend-ts-lexical-missing-source-"));
+  const corpus: LexicalCorpusConfig = {
+    name: "missing_source",
+    sourceRoot: path.join(root, "missing-source"),
+    fileGlobSuffix: ".md",
+    dbPath: path.join(root, "fts.sqlite3"),
+  };
+
+  const results = searchLexicalCorpus(corpus, "windshield rivet", { limit: 5 });
+
+  assert.deepEqual(results, []);
+});


### PR DESCRIPTION
## Summary
- Replace the prod API data prep step with a retrieval artifact gate: download cached artifacts, validate source/code/model fingerprints, rebuild full retrieval artifacts only when stale or missing.
- Include lexical/vector-export artifacts in the API image version hash and upload refreshed retrieval cache artifacts to Scaleway when CI credentials are present.
- Keep the runtime lexical fallback from crashing if an empty index has no source directory, but the build now guarantees the real artifacts instead of relying on runtime rebuild.

## Verification
- `make api-test` (61/61 passing)
- `make api-contracts`
- `git diff --check`