### PR TITLE
Fix CI retrieval ensure without PDF pages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,11 +137,11 @@ dataprep-knowledge-tech-docs: api-install
 
 dataprep-knowledge-ci: dataprep-download-retrieval-inputs api-install
 	@echo "▶ Preparing knowledge artifacts for API image..."
-	cd backend-ts && npm run dataprep:knowledge
+	cd backend-ts && npm run dataprep:knowledge:ci
 
 dataprep-retrieval-ci: dataprep-download-retrieval-inputs api-install
 	@echo "▶ Ensuring retrieval artifacts for API image..."
-	cd backend-ts && npm run dataprep:ensure-retrieval
+	cd backend-ts && npm run dataprep:ensure-retrieval:ci
 	$(MAKE) dataprep-upload-retrieval-cache
 
 check: ui-build api-test api-contracts

--- a/backend-ts/package.json
+++ b/backend-ts/package.json
@@ -18,7 +18,9 @@
     "dataprep:tech-docs": "npm run dataprep:prepare-tech-docs && node --experimental-strip-types scripts/run_dataprep.ts tech_docs",
     "dataprep:nc": "node --experimental-strip-types scripts/run_dataprep.ts non_conformities",
     "dataprep:ensure-retrieval": "npm run dataprep:prepare-tech-docs && node --experimental-strip-types scripts/ensure_retrieval_artifacts.ts all",
+    "dataprep:ensure-retrieval:ci": "node --experimental-strip-types scripts/ensure_retrieval_artifacts.ts all",
     "dataprep:knowledge": "npm run dataprep:prepare-tech-docs && node --experimental-strip-types scripts/run_knowledge_dataprep.ts all",
+    "dataprep:knowledge:ci": "node --experimental-strip-types scripts/run_knowledge_dataprep.ts all",
     "dataprep:knowledge:tech-docs": "npm run dataprep:prepare-tech-docs && node --experimental-strip-types scripts/run_knowledge_dataprep.ts tech_docs"
   }
 }

--- a/backend-ts/test/makefile-ci-targets.test.ts
+++ b/backend-ts/test/makefile-ci-targets.test.ts
@@ -3,6 +3,9 @@ import { readFileSync } from "node:fs";
 import { test } from "node:test";
 
 const makefile = readFileSync(new URL("../../Makefile", import.meta.url), "utf8");
+const packageJson = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8")) as {
+  scripts: Record<string, string>;
+};
 
 function targetPrerequisites(target: string): string[] {
   const match = makefile.match(new RegExp(`^${target}:([^\\n]*)`, "m"));
@@ -19,4 +22,17 @@ test("API image check only prepares retrieval artifacts, not runtime PDF assets"
 test("API build downloads runtime assets after retrieval artifacts are ready", () => {
   assert.deepEqual(targetPrerequisites("api-build"), ["api-prepare-data-ci", "api-runtime-data-ci"]);
   assert.deepEqual(targetPrerequisites("api-runtime-data-ci"), ["dataprep-download-runtime-assets"]);
+});
+
+test("CI retrieval ensure uses the prepared dataset without requiring PDF pages", () => {
+  assert.match(makefile, /npm run dataprep:ensure-retrieval:ci/);
+  assert.equal(
+    packageJson.scripts["dataprep:ensure-retrieval:ci"],
+    "node --experimental-strip-types scripts/ensure_retrieval_artifacts.ts all",
+  );
+  assert.match(makefile, /npm run dataprep:knowledge:ci/);
+  assert.equal(
+    packageJson.scripts["dataprep:knowledge:ci"],
+    "node --experimental-strip-types scripts/run_knowledge_dataprep.ts all",
+  );
 });


### PR DESCRIPTION
## Summary

- Add CI-only dataprep scripts that consume the already prepared datasets from SCW without regenerating the tech-doc CSV.
- Point `dataprep-retrieval-ci` and `dataprep-knowledge-ci` to those CI scripts, so `api-image-check` does not need `tech-docs/pages`.
- Extend the Makefile regression test to cover the CI-only script path.

## Verification

- `node --experimental-strip-types test/makefile-ci-targets.test.ts`
- `make api-test`
- `make -n api-image-check | grep -E 'pages|json/|prepare-tech-docs' || true` produced no matches
- `make -n api-build | grep -E 'pages|json/|dataprep:ensure-retrieval:ci'`
- `git diff --check`