### PR TITLE
Upload canonical tech-doc dataset with retrieval cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -251,6 +251,8 @@ dataprep-upload-retrieval-cache: check-s5cmd
 		echo "▶ Uploading retrieval cache artifacts to Scaleway..."; \
 		export AWS_ACCESS_KEY_ID=${S3_DATAPREP_ACCESS_KEY}; \
 		export AWS_SECRET_ACCESS_KEY=${S3_DATAPREP_SECRET_KEY}; \
+		s5cmd --endpoint-url ${S3_ENDPOINT_URL} cp --acl "public-read" 'api/data/${TECH_DOCS_DIR}/managed_dataset/a220_tech_docs_content_canonical.csv.gz' s3://${S3_BUCKET_DOCS}/managed_dataset/a220_tech_docs_content_canonical.csv.gz && \
+		s5cmd --endpoint-url ${S3_ENDPOINT_URL} cp --acl "public-read" 'api/data/${TECH_DOCS_DIR}/managed_dataset/a220_tech_docs_content_canonical.audit.json' s3://${S3_BUCKET_DOCS}/managed_dataset/a220_tech_docs_content_canonical.audit.json && \
 		s5cmd --endpoint-url ${S3_ENDPOINT_URL} cp --acl "public-read" 'api/data/${TECH_DOCS_DIR}/lexical/*' s3://${S3_BUCKET_DOCS}/lexical/ && \
 		s5cmd --endpoint-url ${S3_ENDPOINT_URL} cp --acl "public-read" 'api/data/${TECH_DOCS_DIR}/vector-export/*' s3://${S3_BUCKET_DOCS}/vector-export/ && \
 		s5cmd --endpoint-url ${S3_ENDPOINT_URL} cp --acl "public-read" 'api/data/${TECH_DOCS_DIR}/ontology/*' s3://${S3_BUCKET_DOCS}/ontology/ && \

--- a/backend-ts/test/makefile-ci-targets.test.ts
+++ b/backend-ts/test/makefile-ci-targets.test.ts
@@ -36,3 +36,8 @@ test("CI retrieval ensure uses the prepared dataset without requiring PDF pages"
     "node --experimental-strip-types scripts/run_knowledge_dataprep.ts all",
   );
 });
+
+test("retrieval cache upload publishes the canonical tech-doc dataset", () => {
+  assert.match(makefile, /a220_tech_docs_content_canonical\.csv\.gz/);
+  assert.match(makefile, /a220_tech_docs_content_canonical\.audit\.json/);
+});


### PR DESCRIPTION
## Summary

- Publish `a220_tech_docs_content_canonical.csv.gz` and its audit as part of the retrieval cache upload path.
- Add a Makefile regression assertion so the canonical dataset stays in the CI cache contract.
- The current missing canonical dataset was also uploaded to SCW manually to unblock the active CD.

## Verification

- `node --experimental-strip-types test/makefile-ci-targets.test.ts`
- `make api-test`
- `git diff --check`