### PR TITLE
Fix API image check lightweight path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ docker-login:
 	@echo "▶ Logging in to registry"
 	@echo "$(DOCKER_PASSWORD)" | docker login $(REGISTRY) -u $(DOCKER_USERNAME) --password-stdin
 
-api-image-check: api-prepare-data-ci docker-login
+api-image-check: dataprep-download-retrieval-inputs docker-login
 	@echo "▶ Checking if image $(REGISTRY)/$(API_IMAGE_NAME):$(API_VERSION) exists"
 	docker manifest inspect $(REGISTRY)/$(API_IMAGE_NAME):$(API_VERSION) >/dev/null 2>&1 && echo "✅ Image $(REGISTRY)/$(API_IMAGE_NAME):$(API_VERSION) exists" || (echo "❌ Image $(REGISTRY)/$(API_IMAGE_NAME):$(API_VERSION) does not exist" && exit 1)
 

--- a/backend-ts/test/makefile-ci-targets.test.ts
+++ b/backend-ts/test/makefile-ci-targets.test.ts
@@ -19,6 +19,10 @@ test("API image check only prepares retrieval artifacts, not runtime PDF assets"
   assert.ok(!targetPrerequisites("dataprep-retrieval-ci").includes("dataprep-download-minimal"));
 });
 
+test("API image check does not install dependencies or regenerate retrieval artifacts", () => {
+  assert.deepEqual(targetPrerequisites("api-image-check"), ["dataprep-download-retrieval-inputs", "docker-login"]);
+});
+
 test("API build downloads runtime assets after retrieval artifacts are ready", () => {
   assert.deepEqual(targetPrerequisites("api-build"), ["api-prepare-data-ci", "api-runtime-data-ci"]);
   assert.deepEqual(targetPrerequisites("api-runtime-data-ci"), ["dataprep-download-runtime-assets"]);


### PR DESCRIPTION
## Summary
- keep `api-image-check` on retrieval artifact download + docker manifest check only
- avoid `api-install`, retrieval regeneration and cache upload before image existence check
- add Makefile regression coverage for the lightweight image-check path

## Verification
- `node --experimental-strip-types test/makefile-ci-targets.test.ts`
- `make -n api-image-check | grep -E 'npm ci|dataprep:ensure|dataprep-upload|prepare-tech-docs|pages|json/' || true`
- `make api-test`
- `git diff --check`