### PR TITLE
Use dataprep S3 secrets for cache upload

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -41,8 +41,8 @@ jobs:
           DOCKER_USERNAME: nologin
           DOCKER_PASSWORD: ${{ secrets.SCW_SECRET_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          S3_DATAPREP_ACCESS_KEY: ${{ secrets.SCW_ACCESS_KEY }}
-          S3_DATAPREP_SECRET_KEY: ${{ secrets.SCW_SECRET_KEY }}
+          S3_DATAPREP_ACCESS_KEY: ${{ secrets.S3_DATAPREP_ACCESS_KEY }}
+          S3_DATAPREP_SECRET_KEY: ${{ secrets.S3_DATAPREP_SECRET_KEY }}
         continue-on-error: true
 
       - name: Capture API version
@@ -54,8 +54,8 @@ jobs:
         env:
           REGISTRY: ${{ secrets.REGISTRY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          S3_DATAPREP_ACCESS_KEY: ${{ secrets.SCW_ACCESS_KEY }}
-          S3_DATAPREP_SECRET_KEY: ${{ secrets.SCW_SECRET_KEY }}
+          S3_DATAPREP_ACCESS_KEY: ${{ secrets.S3_DATAPREP_ACCESS_KEY }}
+          S3_DATAPREP_SECRET_KEY: ${{ secrets.S3_DATAPREP_SECRET_KEY }}
           API_VERSION: ${{ steps.api_version.outputs.api_version }}
         if: steps.image-check.outcome == 'failure'
 

--- a/backend-ts/test/github-workflows.test.ts
+++ b/backend-ts/test/github-workflows.test.ts
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const deployApiWorkflow = readFileSync(new URL("../../.github/workflows/deploy-api.yml", import.meta.url), "utf8");
+
+test("API deploy workflow uses dedicated dataprep S3 secrets for cache upload", () => {
+  assert.match(deployApiWorkflow, /S3_DATAPREP_ACCESS_KEY:\s+\$\{\{\s*secrets\.S3_DATAPREP_ACCESS_KEY\s*\}\}/u);
+  assert.match(deployApiWorkflow, /S3_DATAPREP_SECRET_KEY:\s+\$\{\{\s*secrets\.S3_DATAPREP_SECRET_KEY\s*\}\}/u);
+  assert.doesNotMatch(deployApiWorkflow, /S3_DATAPREP_ACCESS_KEY:\s+\$\{\{\s*secrets\.SCW_ACCESS_KEY\s*\}\}/u);
+  assert.doesNotMatch(deployApiWorkflow, /S3_DATAPREP_SECRET_KEY:\s+\$\{\{\s*secrets\.SCW_SECRET_KEY\s*\}\}/u);
+});


### PR DESCRIPTION
## Summary
- use dedicated `S3_DATAPREP_ACCESS_KEY` / `S3_DATAPREP_SECRET_KEY` GitHub secrets in the API deploy workflow
- stop mapping dataprep upload credentials to the generic `SCW_*` secrets
- add regression coverage for the workflow secret mapping

## Evidence
- failing run `24696362366` rebuilt retrieval artifacts, then failed at `dataprep-upload-retrieval-cache` with `AccessDenied: status code 403`
- local canary upload/read/delete passed on both `a220-tech-docs` and `a220-non-conformities` with the dedicated `S3_DATAPREP_*` keys
- GitHub repo now has `S3_DATAPREP_ACCESS_KEY` and `S3_DATAPREP_SECRET_KEY` secrets set

## Verification
- `node --experimental-strip-types test/github-workflows.test.ts` red before the workflow change, green after
- `make api-test`
- `git diff --check`

No merge performed.