### PR TITLE
Fix empty wiki parts upload in retrieval cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -257,13 +257,13 @@ dataprep-upload-retrieval-cache: check-s5cmd
 		s5cmd --endpoint-url ${S3_ENDPOINT_URL} cp --acl "public-read" 'api/data/${TECH_DOCS_DIR}/vector-export/*' s3://${S3_BUCKET_DOCS}/vector-export/ && \
 		s5cmd --endpoint-url ${S3_ENDPOINT_URL} cp --acl "public-read" 'api/data/${TECH_DOCS_DIR}/ontology/*' s3://${S3_BUCKET_DOCS}/ontology/ && \
 		s5cmd --endpoint-url ${S3_ENDPOINT_URL} cp --acl "public-read" 'api/data/${TECH_DOCS_DIR}/wiki/index.json' s3://${S3_BUCKET_DOCS}/wiki/index.json && \
-		if [ -d 'api/data/${TECH_DOCS_DIR}/wiki/parts' ]; then s5cmd --endpoint-url ${S3_ENDPOINT_URL} cp --acl "public-read" 'api/data/${TECH_DOCS_DIR}/wiki/parts/*' s3://${S3_BUCKET_DOCS}/wiki/parts/; fi && \
+		if [ -d 'api/data/${TECH_DOCS_DIR}/wiki/parts' ] && find 'api/data/${TECH_DOCS_DIR}/wiki/parts' -type f -name '*.md' | grep -q .; then s5cmd --endpoint-url ${S3_ENDPOINT_URL} cp --acl "public-read" 'api/data/${TECH_DOCS_DIR}/wiki/parts/*' s3://${S3_BUCKET_DOCS}/wiki/parts/; fi && \
 		s5cmd --endpoint-url ${S3_ENDPOINT_URL} cp --acl "public-read" 'api/data/${TECH_DOCS_DIR}/knowledge-manifest.json' s3://${S3_BUCKET_DOCS}/knowledge-manifest.json && \
 		s5cmd --endpoint-url ${S3_ENDPOINT_URL} cp --acl "public-read" 'api/data/${NC_DIR}/lexical/*' s3://${S3_BUCKET_NC}/lexical/ && \
 		s5cmd --endpoint-url ${S3_ENDPOINT_URL} cp --acl "public-read" 'api/data/${NC_DIR}/vector-export/*' s3://${S3_BUCKET_NC}/vector-export/ && \
 		s5cmd --endpoint-url ${S3_ENDPOINT_URL} cp --acl "public-read" 'api/data/${NC_DIR}/ontology/*' s3://${S3_BUCKET_NC}/ontology/ && \
 		s5cmd --endpoint-url ${S3_ENDPOINT_URL} cp --acl "public-read" 'api/data/${NC_DIR}/wiki/index.json' s3://${S3_BUCKET_NC}/wiki/index.json && \
-		if [ -d 'api/data/${NC_DIR}/wiki/parts' ]; then s5cmd --endpoint-url ${S3_ENDPOINT_URL} cp --acl "public-read" 'api/data/${NC_DIR}/wiki/parts/*' s3://${S3_BUCKET_NC}/wiki/parts/; fi && \
+		if [ -d 'api/data/${NC_DIR}/wiki/parts' ] && find 'api/data/${NC_DIR}/wiki/parts' -type f -name '*.md' | grep -q .; then s5cmd --endpoint-url ${S3_ENDPOINT_URL} cp --acl "public-read" 'api/data/${NC_DIR}/wiki/parts/*' s3://${S3_BUCKET_NC}/wiki/parts/; fi && \
 		s5cmd --endpoint-url ${S3_ENDPOINT_URL} cp --acl "public-read" 'api/data/${NC_DIR}/knowledge-manifest.json' s3://${S3_BUCKET_NC}/knowledge-manifest.json; \
 	fi
 

--- a/backend-ts/test/makefile-ci-targets.test.ts
+++ b/backend-ts/test/makefile-ci-targets.test.ts
@@ -45,3 +45,8 @@ test("retrieval cache upload publishes the canonical tech-doc dataset", () => {
   assert.match(makefile, /a220_tech_docs_content_canonical\.csv\.gz/);
   assert.match(makefile, /a220_tech_docs_content_canonical\.audit\.json/);
 });
+
+test("retrieval cache upload skips empty wiki parts directories", () => {
+  assert.match(makefile, /find 'api\/data\/\$\{TECH_DOCS_DIR\}\/wiki\/parts' -type f -name '\*\.md' \| grep -q \./);
+  assert.match(makefile, /find 'api\/data\/\$\{NC_DIR\}\/wiki\/parts' -type f -name '\*\.md' \| grep -q \./);
+});


### PR DESCRIPTION
## Summary
- skip optional wiki parts uploads when the directory exists but contains no markdown files
- add Makefile regression coverage for empty wiki parts directories
- manually restored the missing NC `knowledge-manifest.json` in S3 using the current prepared dataset fingerprint

## Verification
- `node --experimental-strip-types test/makefile-ci-targets.test.ts`
- `make api-test`
- `make api-prepare-data-ci` confirmed `retrieval artifacts fresh: tech_docs` and `retrieval artifacts fresh: non_conformities` without embedding rebuild