### PR TITLE
Skip retrieval cache upload when artifacts are fresh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,9 +140,14 @@ dataprep-knowledge-ci: dataprep-download-retrieval-inputs api-install
 	cd backend-ts && npm run dataprep:knowledge:ci
 
 dataprep-retrieval-ci: dataprep-download-retrieval-inputs api-install
+	@rm -f .dataprep-retrieval-rebuilt
 	@echo "▶ Ensuring retrieval artifacts for API image..."
-	cd backend-ts && npm run dataprep:ensure-retrieval:ci
-	$(MAKE) dataprep-upload-retrieval-cache
+	cd backend-ts && DATAPREP_REBUILD_MARKER=../.dataprep-retrieval-rebuilt npm run dataprep:ensure-retrieval:ci
+	@if [ -f .dataprep-retrieval-rebuilt ]; then \
+		$(MAKE) dataprep-upload-retrieval-cache; \
+	else \
+		echo "↷ Retrieval artifacts fresh; retrieval cache upload skipped."; \
+	fi
 
 check: ui-build api-test api-contracts
 	@echo "✔️ UI build and backend checks completed."

--- a/backend-ts/scripts/ensure_retrieval_artifacts.ts
+++ b/backend-ts/scripts/ensure_retrieval_artifacts.ts
@@ -1,3 +1,4 @@
+import { rmSync, writeFileSync } from "node:fs";
 import {
   DEFAULT_EMBEDDING_MODEL,
   buildDataprepCodeFingerprint,
@@ -16,7 +17,13 @@ const corpusNames: readonly DataprepCorpusName[] =
   requested === "all" ? ["tech_docs", "non_conformities"] : [requested as DataprepCorpusName];
 const configs = buildDefaultCorpusConfigs();
 const codeFingerprint = buildDataprepCodeFingerprint();
+const rebuildMarkerPath = process.env.DATAPREP_REBUILD_MARKER?.trim();
+const rebuiltCorpora: DataprepCorpusName[] = [];
 let options: RunDataprepOptions | null = null;
+
+if (rebuildMarkerPath) {
+  rmSync(rebuildMarkerPath, { force: true });
+}
 
 for (const corpus of corpusNames) {
   const config = configs[corpus];
@@ -45,5 +52,10 @@ for (const corpus of corpusNames) {
 
   options ??= buildDataprepCliOptions();
   await runDataprepForCorpus(config, options);
+  rebuiltCorpora.push(corpus);
   console.log(`retrieval artifacts rebuilt: ${corpus} (${records.length} records)`);
+}
+
+if (rebuildMarkerPath && rebuiltCorpora.length > 0) {
+  writeFileSync(rebuildMarkerPath, `${rebuiltCorpora.join("\n")}\n`);
 }

--- a/backend-ts/test/makefile-ci-targets.test.ts
+++ b/backend-ts/test/makefile-ci-targets.test.ts
@@ -3,6 +3,10 @@ import { readFileSync } from "node:fs";
 import { test } from "node:test";
 
 const makefile = readFileSync(new URL("../../Makefile", import.meta.url), "utf8");
+const ensureRetrievalScript = readFileSync(
+  new URL("../scripts/ensure_retrieval_artifacts.ts", import.meta.url),
+  "utf8",
+);
 const packageJson = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8")) as {
   scripts: Record<string, string>;
 };
@@ -49,4 +53,16 @@ test("retrieval cache upload publishes the canonical tech-doc dataset", () => {
 test("retrieval cache upload skips empty wiki parts directories", () => {
   assert.match(makefile, /find 'api\/data\/\$\{TECH_DOCS_DIR\}\/wiki\/parts' -type f -name '\*\.md' \| grep -q \./);
   assert.match(makefile, /find 'api\/data\/\$\{NC_DIR\}\/wiki\/parts' -type f -name '\*\.md' \| grep -q \./);
+});
+
+test("CI retrieval cache upload runs only after an actual rebuild", () => {
+  assert.match(makefile, /DATAPREP_REBUILD_MARKER=\.\.\/\.dataprep-retrieval-rebuilt/);
+  assert.match(makefile, /if \[ -f \.dataprep-retrieval-rebuilt \]; then \\\s*\$\(MAKE\) dataprep-upload-retrieval-cache;/);
+  assert.match(makefile, /Retrieval artifacts fresh; retrieval cache upload skipped/);
+});
+
+test("retrieval ensure script emits a rebuild marker for CI upload gating", () => {
+  assert.match(ensureRetrievalScript, /DATAPREP_REBUILD_MARKER/);
+  assert.match(ensureRetrievalScript, /writeFileSync\(rebuildMarkerPath/);
+  assert.match(ensureRetrievalScript, /rebuiltCorpora/);
 });


### PR DESCRIPTION
## Summary
- Gate `dataprep-upload-retrieval-cache` behind an explicit rebuild marker emitted by `ensure_retrieval_artifacts.ts`.
- Keep the CI rebuild path unchanged when artifacts are stale, but skip the expensive flat-file S3 upload when both corpora are already fresh.
- Add regression coverage for the Make target and rebuild marker contract.

## Verification
- `make api-prepare-data-ci` confirmed fresh artifacts for `tech_docs` and `non_conformities`, then printed `Retrieval artifacts fresh; retrieval cache upload skipped.`
- `make api-test` passed: 71/71 tests.
- `git diff --check`
- `test ! -f .dataprep-retrieval-rebuilt`